### PR TITLE
Fixup usize arith

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "memory_addresses"
 readme = "README.md"
 repository = "https://github.com/hermit-os/memory-addresses"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -135,6 +135,41 @@ impl From<usize> for VirtAddr {
 }
 
 #[cfg(target_pointer_width = "64")]
+// if the target_pointer_width is 64, usize = u64 so we can safely add
+impl core::ops::Add<usize> for VirtAddr {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: usize) -> Self::Output {
+        VirtAddr::new(self.0 + rhs as u64)
+    }
+}
+#[cfg(target_pointer_width = "64")]
+// if the target_pointer_width is 64, usize = u64 so we can safely add
+impl core::ops::AddAssign<usize> for VirtAddr {
+    #[inline]
+    fn add_assign(&mut self, rhs: usize) {
+        *self = *self + rhs;
+    }
+}
+#[cfg(target_pointer_width = "64")]
+// if the target_pointer_width is 64, usize = u64 so we can safely sub
+impl core::ops::Sub<usize> for VirtAddr {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: usize) -> Self::Output {
+        VirtAddr::new(self.0.checked_sub(rhs as u64).unwrap())
+    }
+}
+#[cfg(target_pointer_width = "64")]
+// if the target_pointer_width is 64, usize = u64 so we can safely sub
+impl core::ops::SubAssign<usize> for VirtAddr {
+    #[inline]
+    fn sub_assign(&mut self, rhs: usize) {
+        *self = *self - rhs;
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
 // if the target_pointer_width is 64, usize = u64 so we can safely transform.
 impl From<usize> for PhysAddr {
     fn from(addr: usize) -> PhysAddr {


### PR DESCRIPTION
#14 didn't include usize arithmetics for `riscv64::VirtAddr` by mistake. Now it does.