### PR TITLE
fix: remove paste dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 [dependencies]
 align-address = "0.3.0"
 cfg-if = "1.0.0"
-paste = "1.0.15"
 x86 = { version = "0.52.0", default-features = false, optional = true }
 x86_64 = { version = "0.15.1", default-features = false, optional = true }
 

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -16,7 +16,7 @@ use align_address::Align;
 #[repr(transparent)]
 pub struct VirtAddr(u64);
 
-impl_address!(VirtAddr, u64);
+impl_address!(VirtAddr, u64, as_u64);
 
 /// An invalid virtual address.
 ///
@@ -166,7 +166,7 @@ impl From<usize> for PhysAddr {
 #[repr(transparent)]
 pub struct PhysAddr(u64);
 
-impl_address!(PhysAddr, u64);
+impl_address!(PhysAddr, u64, as_u64);
 
 /// A passed `u64` was not a valid physical address.
 ///

--- a/src/arch/fallback.rs
+++ b/src/arch/fallback.rs
@@ -10,14 +10,14 @@ use align_address::Align;
 #[repr(transparent)]
 pub struct VirtAddr(usize);
 
-impl_address!(VirtAddr, usize);
+impl_address!(VirtAddr, usize, as_usize);
 
 /// A physical memory address.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct PhysAddr(usize);
 
-impl_address!(PhysAddr, usize);
+impl_address!(PhysAddr, usize, as_usize);
 
 /// An invalid virtual address
 pub struct VirtAddrNotValid(pub usize);

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -25,7 +25,7 @@ pub const TERA_PAGE_SIZE: usize = 1024 * 1024 * 1024 * 512;
 #[repr(transparent)]
 pub struct VirtAddr(u64);
 
-impl_address!(VirtAddr, u64);
+impl_address!(VirtAddr, u64, as_u64);
 
 /// An invalid virtual address.
 pub struct VirtAddrNotValid(pub u64);
@@ -184,7 +184,7 @@ impl From<usize> for PhysAddr {
 #[repr(transparent)]
 pub struct PhysAddr(u64);
 
-impl_address!(PhysAddr, u64);
+impl_address!(PhysAddr, u64, as_u64);
 
 /// A passed `u64` was not a valid physical address.
 ///

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -24,7 +24,7 @@ use x86_64::structures::paging::{PageOffset, PageTableIndex};
 #[repr(transparent)]
 pub struct VirtAddr(u64);
 
-impl_address!(VirtAddr, u64);
+impl_address!(VirtAddr, u64, as_u64);
 
 /// A 64-bit physical memory address.
 ///
@@ -39,7 +39,7 @@ impl_address!(VirtAddr, u64);
 #[repr(transparent)]
 pub struct PhysAddr(u64);
 
-impl_address!(PhysAddr, u64);
+impl_address!(PhysAddr, u64, as_u64);
 
 /// A passed `u64` was not a valid virtual address.
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,7 @@
 /// Macro that implements the functionalities that every address type has.
 /// Inspired/adopted from https://github.com/rust-vmm/vm-memory
 macro_rules! impl_address {
-    ($T:ident, $V:ty) => {
+    ($T:ident, $V:ty, $as_V:ident) => {
         impl $crate::MemoryAddress for $T {
             type RAW = $V;
 
@@ -37,12 +37,10 @@ macro_rules! impl_address {
                 $T::new(0)
             }
 
-            paste::paste! {
-                #[doc = "Converts the address to an `" $V "`."]
-                #[inline]
-                pub const fn [< as_ $V >] (self) -> $V {
-                    self.0
-                }
+            #[doc = concat!("Converts the address to an `", stringify!($V), "`.")]
+            #[inline]
+            pub const fn $as_V(self) -> $V {
+                self.0
             }
         }
 
@@ -80,9 +78,7 @@ macro_rules! impl_address {
             type Output = $V;
             #[inline]
             fn sub(self, rhs: $T) -> Self::Output {
-                paste::paste! {
-                    self.[< as _$V >]().checked_sub(rhs.[< as_ $V >]()).unwrap()
-                }
+                self.$as_V().checked_sub(rhs.$as_V()).unwrap()
             }
         }
 


### PR DESCRIPTION
This removes the unmaintained paste dependency while keeping the generated code exactly the same.

Closes https://github.com/hermit-os/memory-addresses/issues/16.