### PR TITLE
Iter rework

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,6 +439,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::iter_nth_zero)]
     fn test_addr_range() {
         let r = AddrRange::new(VirtAddr::new(0x0), VirtAddr::new(0x3)).unwrap();
         assert!(r.contains(&VirtAddr::new(0x0)));
@@ -489,6 +490,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::iter_nth_zero)]
     fn test_iter_incl() {
         let range = VirtAddr::new(0x0)..=VirtAddr::new(0x3);
         let mut i = AddrIter::from(range.clone());


### PR DESCRIPTION
pr for #19

- Defined `AddrIter` to panic when iterating over non-canonical addresses.
- Implemented `DoubleEndedIterator` and `ExactSizeIterator`
- Added a number of method implementations for iterator traits to reduce unnecessary calls to `Iterator::next()`
- Added an inclusive variant of the iterator. This is required because it cannot return the last address in a range without it. (e.g it will never return `0x7FFFFFFFFFFF` it will stop at `0x7FFFFFFFFFFE`).
- Added `From<Range>` and `From<RangeInclusive>` for `AddrIter`

8637ae6 requires that `MemoryAddress::RAW` implements `TryFrom<usize>`, I don't really like further restricting it but it already implements `TryInto<usize>` so it probably wont be an issue.

There may be bugs where iterating to a non-canonical address when `add`/`sub_checked()` returns `None`, by assuming its an overflow, when it should be checked. I think I caught them all but there might be more.