### PR TITLE
feat: upgrade to align-address 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.2.4"
 edition = "2021"
 
 [dependencies]
-align-address = "0.3.0"
+align-address = "0.4"
 cfg-if = "1.0.0"
 x86 = { version = "0.52.0", default-features = false, optional = true }
 x86_64 = { version = "0.15.1", default-features = false, optional = true }

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -99,8 +99,9 @@ impl Align<u64> for VirtAddr {
     }
 
     #[inline]
-    fn align_up(self, align: u64) -> Self {
-        Self::new_truncate(self.0.align_up(align))
+    fn checked_align_up(self, align: u64) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        Some(Self::new_truncate(addr))
     }
 }
 
@@ -265,8 +266,10 @@ impl Align<u64> for PhysAddr {
     }
 
     #[inline]
-    fn align_up(self, align: u64) -> Self {
-        Self::new(self.0.align_up(align))
+    fn checked_align_up(self, align: u64) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        let this = Self::try_new(addr).ok()?;
+        Some(this)
     }
 }
 
@@ -336,6 +339,10 @@ mod tests {
             VirtAddr::new(0x000f_ffff_ffff_ffff).align_up(2u64),
             VirtAddr::new(0xfff0_0000_0000_0000)
         );
+        assert_eq!(
+            VirtAddr::new(0xffff_ffff_ffff_ffff).checked_align_up(2u64),
+            None
+        )
     }
 
     #[test]
@@ -355,15 +362,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_virt_addr_align_up_overflow() {
-        let _ = VirtAddr::new(0xffff_ffff_ffff_ffff).align_up(2u64);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_phys_addr_align_up_overflow() {
-        PhysAddr::new(0x00ff_ffff_ffff_ffff).align_up(2u64);
+    fn test_phys_addr_align_up() {
+        assert_eq!(
+            PhysAddr::new(0x00ff_ffff_ffff_ffff).checked_align_up(2u64),
+            None
+        );
     }
 
     #[test]

--- a/src/arch/fallback.rs
+++ b/src/arch/fallback.rs
@@ -75,8 +75,9 @@ impl Align<usize> for VirtAddr {
     }
 
     #[inline]
-    fn align_up(self, align: usize) -> Self {
-        Self::new_truncate(self.0.align_up(align))
+    fn checked_align_up(self, align: usize) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        Some(Self::new_truncate(addr))
     }
 }
 
@@ -124,8 +125,10 @@ impl Align<usize> for PhysAddr {
     }
 
     #[inline]
-    fn align_up(self, align: usize) -> Self {
-        Self::new(self.0.align_up(align))
+    fn checked_align_up(self, align: usize) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        let this = Self::try_new(addr).ok()?;
+        Some(this)
     }
 }
 

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_phys_addr_align_up_overflow() {
-        PhysAddr::new(0x00ff_ffff_ffff_ffff).align_up(2u64);
+        PhysAddr::new(0x003f_ffff_ffff_ffff).align_up(2u64);
     }
 
     #[test]

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -121,8 +121,9 @@ impl Align<u64> for VirtAddr {
     }
 
     #[inline]
-    fn align_up(self, align: u64) -> Self {
-        Self::new_truncate(self.0.align_up(align))
+    fn checked_align_up(self, align: u64) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        Some(Self::new_truncate(addr))
     }
 }
 
@@ -243,8 +244,10 @@ impl Align<u64> for PhysAddr {
     }
 
     #[inline]
-    fn align_up(self, align: u64) -> Self {
-        Self::new(self.0.align_up(align))
+    fn checked_align_up(self, align: u64) -> Option<Self> {
+        let addr = self.0.checked_align_up(align)?;
+        let this = Self::try_new(addr).ok()?;
+        Some(this)
     }
 }
 
@@ -354,6 +357,10 @@ mod tests {
             VirtAddr::new(0x0000_7fff_ffff_ffff).align_up(2u64),
             VirtAddr::new(0xffff_8000_0000_0000)
         );
+        assert_eq!(
+            VirtAddr::new(0xffff_ffff_ffff_ffff).checked_align_up(2u64),
+            None
+        );
     }
 
     #[test]
@@ -373,15 +380,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_virt_addr_align_up_overflow() {
-        let _ = VirtAddr::new(0xffff_ffff_ffff_ffff).align_up(2u64);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_phys_addr_align_up_overflow() {
-        PhysAddr::new(0x003f_ffff_ffff_ffff).align_up(2u64);
+    fn test_phys_addr_align_up() {
+        assert_eq!(
+            PhysAddr::new(0x003f_ffff_ffff_ffff).checked_align_up(2u64),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR upgrades [align-address](https://github.com/mkroening/align-address) from 0.3 to 0.4.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/mkroening/align-address/releases">align-address's releases</a>.</em></p>
<blockquote>
<h2>0.4.0</h2>
<h3>🚀 Features</h3>
<ul>
<li>Add <code>checked_align_up</code></li>
<li>Add <code>#[must_use]</code> attributes</li>
<li>Add <code>#[track_caller]</code> attributes</li>
<li>Add MSRV of 1.57</li>
</ul>
<h3>⚙️ Miscellaneous Tasks</h3>
<ul>
<li>Add <code>Cargo.lock</code></li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/mkroening/align-address/commit/d48d9bebd20e957544786bdbd350d35318f80d32"><code>d48d9be</code></a> chore: release version 0.4.0</li>
<li><a href="https://github.com/mkroening/align-address/commit/d3ac74bd17ea2fd5dc02f09afce670a1aa7fb80a"><code>d3ac74b</code></a> chore: add <code>Cargo.lock</code></li>
<li><a href="https://github.com/mkroening/align-address/commit/4e1191f089b0f725d1db067abd1cef791e8d7708"><code>4e1191f</code></a> feat: add MSRV of 1.57</li>
<li><a href="https://github.com/mkroening/align-address/commit/01fe4741e2f09e89db43f5dcb1e482a2e91f39f2"><code>01fe474</code></a> feat: add <code>#[track_caller]</code> attributes</li>
<li><a href="https://github.com/mkroening/align-address/commit/536d9b49073283de9ef148809b99f95ecf16e98e"><code>536d9b4</code></a> feat: add <code>#[must_use]</code> attributes</li>
<li><a href="https://github.com/mkroening/align-address/commit/fa20c20d3b8a632ab240ac9a36aad3f66c1681dd"><code>fa20c20</code></a> Merge pull request <a href="https://redirect.github.com/mkroening/align-address/issues/4">#4</a> from mkroening/checked</li>
<li><a href="https://github.com/mkroening/align-address/commit/d3d7cfb900cd006613de579324e59cd4f54cb7ff"><code>d3d7cfb</code></a> feat: add <code>checked_align_up</code></li>
<li><a href="https://github.com/mkroening/align-address/commit/c55bba99b7b9e1d451375eb362bbe45a9b1b5f6d"><code>c55bba9</code></a> Merge pull request <a href="https://redirect.github.com/mkroening/align-address/issues/3">#3</a> from mkroening/dependabot/github_actions/actions/checko...</li>
<li><a href="https://github.com/mkroening/align-address/commit/9697e3c9a80a76971599d8118266532e73fc1431"><code>9697e3c</code></a> chore(deps): Bump actions/checkout from 5 to 6</li>
<li><a href="https://github.com/mkroening/align-address/commit/5cbfbc15b68fcd60d48a5affbba08fa1a998f8f6"><code>5cbfbc1</code></a> Merge pull request <a href="https://redirect.github.com/mkroening/align-address/issues/2">#2</a> from mkroening/dependabot/github_actions/actions/checko...</li>
<li>Additional commits viewable in <a href="https://github.com/mkroening/align-address/compare/v0.3.0...v0.4.0">compare view</a></li>
</ul>
</details>
<br />

Unfortunately, this is a breaking change since we publicly implement this trait. We should yank the last version anyway, though, and release a new minor version: https://github.com/hermit-os/memory-addresses/issues/26

To work around update failures such as https://github.com/hermit-os/kernel/pull/2202 and https://github.com/hermit-os/uhyve/pull/1231, we could publicly reexport the `Align` trait. This is not enforceable, though, and I don't think this is preferable.
